### PR TITLE
Add some semblance of a build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /tundra-nat64.conf
 /test_deploy
 /TODO-private.txt
+*.o
+*.d

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /TODO-private.txt
 *.o
 *.d
+*.8

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+
+PREFIX ?= /usr/local
+
+WARN_FLAGS = -Wall -Wextra -Wpedantic
+OPT_FLAGS = -O3 -flto
+ALLFLAGS = -pthread # passed to both compiling/linking stages
+CFLAGS += -MD -MP -std=c11 $(WARN_FLAGS) $(OPT_FLAGS) $(ALLFLAGS)
+LDFLAGS += $(OPT_FLAGS) $(ALLFLAGS)
+
+SRCS := $(wildcard src/*.c)
+OBJS := $(SRCS:.c=.o)
+
+all: tundra-nat64
+.PHONY: all clean install
+
+tundra-nat64: $(OBJS)
+	$(CC) $(LDFLAGS) -o $@ $^
+
+%.o: %.c
+	$(CC) $(CFLAGS) -o $@ -c $<
+
+clean:
+	-rm src/*.o
+	-rm src/*.d
+
+install: tundra-nat64.8
+	install -D -m755 tundra-nat64 -t $(DESTDIR)$(PREFIX)/sbin/
+
+.SUFFIXES:
+
+-include $(OBJS:.o=.d)

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ clean:
 	-rm src/*.o
 	-rm src/*.d
 	-rm *.8
+	-rm tundra-nat64
 
 install: tundra-nat64.8
 	install -D -m755 tundra-nat64 -t $(DESTDIR)$(PREFIX)/sbin/

--- a/Makefile
+++ b/Makefile
@@ -19,12 +19,22 @@ tundra-nat64: $(OBJS)
 %.o: %.c
 	$(CC) $(CFLAGS) -o $@ -c $<
 
+HELP2MAN_FLAGS = \
+ --no-info --no-discard-stderr \
+ --name='a multithreaded IPv6 to IPv4 packet translator' \
+ --section=8
+
+tundra-nat64.8: tundra-nat64
+	PATH=$$PWD:$$PATH help2man $(HELP2MAN_FLAGS) $< >$@ || rm $@
+
 clean:
 	-rm src/*.o
 	-rm src/*.d
+	-rm *.8
 
 install: tundra-nat64.8
 	install -D -m755 tundra-nat64 -t $(DESTDIR)$(PREFIX)/sbin/
+	install -D -m644 tundra-nat64.8 -t $(DESTDIR)$(PREFIX)/share/man/man8/
 
 .SUFFIXES:
 

--- a/README.md
+++ b/README.md
@@ -89,15 +89,11 @@ up.
 
 
 ## Build
-Since Tundra has no dependencies other than Linux's standard C library and `libpthread`, it can be compiled by a single 
-command and without the use of a build system: 
-```shell
-gcc -Wall -Wextra -pthread -std=c11 -O3 -flto -o tundra-nat64 src/t64_*.c
-```
-Both `gcc` and `clang` may be used to compile the program.
 
+Run `make` to build Tundra. The Makefile supports the usual `all`,
+`install` and `clean` targets. Both `gcc` and `clang` are supported.
 
-
+No dependencies other than `pthread` are required.
 
 
 ## Configuration & usage

--- a/src/t64_conf_cmdline.c
+++ b/src/t64_conf_cmdline.c
@@ -32,7 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 \n\
 Usage: %s [OPTION]... [MODE_OF_OPERATION]\n\
 \n\
-Options:\n\
+*OPTIONS*\n\
   -h, --"T64C_CONF_CMDLINE__LONGOPT_HELP"\n\
     Prints help and exits.\n\
   -v, --"T64C_CONF_CMDLINE__LONGOPT_VERSION"\n\
@@ -43,25 +43,29 @@ Options:\n\
     Specifies the file from which the program's configuration will be loaded.\n\
     DEFAULT: "T64C_TUNDRA__DEFAULT_CONFIG_FILE_PATH"\n\
     NOTE: To load the configuration from standard input, specify '-' as the config file path.\n\
-  -f, --"T64C_CONF_CMDLINE__LONGOPT_IO_INHERITED_FDS"=THREAD1_IN,THREAD1_OUT[;THREAD2_IN,THREAD2_OUT]...\n\
-    Specifies the file descriptors to be used in the '"T64C_CONF_FILE__IO_MODE_INHERITED_FDS"' I/O mode. Ignored otherwise.\n\
-  -F, --"T64C_CONF_CMDLINE__LONGOPT_ADDRESSING_EXTERNAL_INHERITED_FDS"=THREAD1_IN,THREAD1_OUT[;THREAD2_IN,THREAD2_OUT]...\n\
+  -f, --"T64C_CONF_CMDLINE__LONGOPT_IO_INHERITED_FDS"=FD_PAIR...\n\
+    Specifies the file descriptors to be used in the 'inherited-fds'\n\
+    I/O mode. Ignored otherwise. The FD_PAIRs consist of comma separated\n\
+    pairs, like in,out and pairs are separated by semicolon.\n\
+  -F, --"T64C_CONF_CMDLINE__LONGOPT_ADDRESSING_EXTERNAL_INHERITED_FDS"=FD_PAIR...\n\
     Specifies the file descriptors to be used for the '"T64C_CONF_FILE__ADDRESSING_EXTERNAL_TRANSPORT_INHERITED_FDS"' transport of the '"T64C_CONF_FILE__ADDRESSING_MODE_EXTERNAL"' addressing mode. Ignored otherwise.\n\
 \n\
-Modes of operation:\n\
-  "T64C_CONF_CMDLINE__OPMODE_TRANSLATE"\n\
-    The program will act as a stateless NAT64/CLAT translator.\n\
-    This is the default mode of operation.\n\
-  "T64C_CONF_CMDLINE__OPMODE_MKTUN"\n\
-    Creates a persistent TUN device according to the configuration file, then exits.\n\
-    Applicable only in the '"T64C_CONF_FILE__IO_MODE_TUN"' I/O mode.\n\
-  "T64C_CONF_CMDLINE__OPMODE_RMTUN"\n\
-    Destroys a previously created persistent TUN device according to the configuration file, then exits.\n\
-    Applicable only in the '"T64C_CONF_FILE__IO_MODE_TUN"' I/O mode.\n\
-  "T64C_CONF_CMDLINE__OPMODE_VALIDATE_CONFIG"\n\
-    Tries to configure the program and prints an informational message if it succeeds, then exits.\n\
-  "T64C_CONF_CMDLINE__OPMODE_PRINT_CONFIG"\n\
-    Prints the program's configuration in a human-readable format, then exits.\n\
+*MODES OF OPERATION*\n\
+  translate  The program will act as a stateless NAT64/CLAT translator.\n\
+             This is the default mode of operation.\n\
+\n\
+  mktun      Creates a persistent TUN device according to the configuration\n\
+             file, then exits. Applicable only in the 'tun' I/O mode.\n\
+\n\
+  rmtun      Destroys a previously created persistent TUN device according to\n\
+             the configuration file, then exits. Applicable only in the 'tun'\n\
+             I/O mode.\n\
+\n\
+  validate-config  Tries to configure the program and prints an\n\
+                   informational message if it succeeds, then exits.\n\
+\n\
+  print-config     Prints the program's configuration in a human-readable\n\
+                   format, then exits.\n\
 \n\
 "
 


### PR DESCRIPTION
Hi Vít,

Not having even so much as a simple Makefile is a disservice to packagers. Every packager for every distribution needs to figure out where to copy the executable, config files and (patch pending) manpages. This is a waste of effort and a Makefile solves this.

--Daniel

  